### PR TITLE
Correct subpackage name in help system

### DIFF
--- a/sptable.hd
+++ b/sptable.hd
@@ -5,12 +5,12 @@ $xrv		= "./src/xrv/"
 
 # Define help files for the packages.
 
-sptod		men = xonedspec$xonedspec.men,
+xonedspec	men = xonedspec$xonedspec.men,
 		hlp = ..,
 		pkg = xonedspec$xonedspec.hd,
 		src = xonedspec$xonedspec.cl
 
-sptrv		men = xrv$xrv.men,
+xrv		men = xrv$xrv.men,
 		hlp = ..,
 		pkg = xrv$xrv.hd,
 		src = xrv$xrv.cl


### PR DESCRIPTION
Without these names, the help files for the sub packages cannot be found. This is relevant for the readthedocs generation; see https://github.com/iraf-community/iraf-readthedocs/pull/4